### PR TITLE
fix: Correct missing icon import and broken API call

### DIFF
--- a/src/components/ScheduledTasks.tsx
+++ b/src/components/ScheduledTasks.tsx
@@ -93,11 +93,7 @@ export const ScheduledTasks = () => {
     if (!user) return;
     
     try {
-      const { data, error } = await supabase
-        .from('family_groups')
-        .select('id, name')
-        .or(`owner_id.eq.${user.id},user_id.eq.${user.id}`, { foreignTable: 'group_members' })
-        .order('name');
+      const { data, error } = await (supabase as any).rpc('get_user_groups');
 
       if (error) throw error;
       setGroups((data || []) as FamilyGroup[]);

--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -5,7 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { Plus, Minus, Loader2, Users, AlertTriangle } from "lucide-react";
+import { Plus, Minus, Loader2, Users, AlertTriangle, Pencil } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/hooks/useAuth";


### PR DESCRIPTION
This commit addresses two bugs that were discovered after the initial implementation of the transaction edit/delete feature:

1.  A `ReferenceError: Pencil is not defined` in `TransactionForm.tsx` has been fixed by adding the missing `Pencil` icon to the `lucide-react` import.
2.  An incorrect Supabase query in `ScheduledTasks.tsx` that was causing errors when fetching family groups has been replaced with a more robust and correct RPC call to `get_user_groups`.

These fixes ensure that the transaction editing UI and the scheduled tasks component load and function correctly.