### PR TITLE
feat: display consolidated open banking data and fix related bugs

### DIFF
--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -286,7 +286,7 @@ const InvestmentsPage = () => {
                         <TableCell>{acc.number}</TableCell>
                         <TableCell>{acc.subtype}</TableCell>
                         <TableCell className="text-right font-medium">
-                          {typeof acc.balance === 'number' ? acc.balance.toLocaleString('pt-BR', { style: 'currency', currency: acc.currency }) : 'N/A'}
+                          {typeof acc.balance === 'number' ? acc.balance.toLocaleString('pt-BR', { style: 'currency', currency: acc.currency || 'BRL' }) : 'N/A'}
                         </TableCell>
                       </TableRow>
                     ))
@@ -374,7 +374,7 @@ const InvestmentsPage = () => {
                           <TableCell className="font-medium">{inv.name}</TableCell>
                           <TableCell>{inv.subtype}</TableCell>
                           <TableCell className="text-right font-medium">
-                            {typeof inv.balance === 'number' ? inv.balance.toLocaleString('pt-BR', { style: 'currency', currency: inv.currency }) : 'N/A'}
+                            {typeof inv.balance === 'number' ? inv.balance.toLocaleString('pt-BR', { style: 'currency', currency: inv.currency || 'BRL' }) : 'N/A'}
                           </TableCell>
                         </TableRow>
                       ))

--- a/supabase/functions/b3-quotes/index.ts
+++ b/supabase/functions/b3-quotes/index.ts
@@ -71,32 +71,42 @@ Deno.serve(async (req) => {
     const yahooData = await yahooResponse.json();
 
     if (!yahooData.quoteResponse || !yahooData.quoteResponse.result) {
-      throw new Error('Resposta inválida do Yahoo Finance');
+      // Se a resposta principal falhar, ainda pode ser um erro de um símbolo específico
+      console.warn('Resposta do Yahoo Finance não contém quoteResponse.result. Verifique os símbolos:', symbols);
+      // Retorna uma lista vazia para não quebrar o front-end
+      return new Response(JSON.stringify({ quotes: [] }), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
     }
 
-    // Processar e formatar dados
-    const quotes = yahooData.quoteResponse.result.map((quote: any, index: number) => {
-      const originalSymbol = symbols[index];
-      
-      return {
-        symbol: originalSymbol,
-        shortName: quote.shortName || originalSymbol,
-        longName: quote.longName || quote.shortName || originalSymbol,
-        currency: quote.currency || 'BRL',
-        regularMarketPrice: quote.regularMarketPrice || 0,
-        regularMarketChange: quote.regularMarketChange || 0,
-        regularMarketChangePercent: quote.regularMarketChangePercent || 0,
-        regularMarketTime: quote.regularMarketTime ? new Date(quote.regularMarketTime * 1000).toISOString() : new Date().toISOString(),
-        marketCap: quote.marketCap || 0,
-        volume: quote.regularMarketVolume || 0,
-        averageDailyVolume3Month: quote.averageDailyVolume3Month || 0,
-        fiftyTwoWeekLow: quote.fiftyTwoWeekLow || 0,
-        fiftyTwoWeekHigh: quote.fiftyTwoWeekHigh || 0,
-        dividendYield: quote.dividendYield || null,
-        trailingPE: quote.trailingPE || null,
-        forwardPE: quote.forwardPE || null,
-      };
-    });
+    // Processar e formatar dados, filtrando resultados nulos ou sem preço
+    const quotes = yahooData.quoteResponse.result
+      .map((quote: any) => {
+        if (!quote || typeof quote.regularMarketPrice !== 'number') {
+          return null; // Ignorar resultados inválidos
+        }
+
+        return {
+          symbol: quote.symbol.replace('.SA', ''), // Mapear de volta para o símbolo original
+          shortName: quote.shortName || quote.symbol.replace('.SA', ''),
+          longName: quote.longName || quote.shortName || quote.symbol.replace('.SA', ''),
+          currency: quote.currency || 'BRL',
+          regularMarketPrice: quote.regularMarketPrice,
+          regularMarketChange: quote.regularMarketChange || 0,
+          regularMarketChangePercent: quote.regularMarketChangePercent || 0,
+          regularMarketTime: quote.regularMarketTime ? new Date(quote.regularMarketTime * 1000).toISOString() : new Date().toISOString(),
+          marketCap: quote.marketCap || 0,
+          volume: quote.regularMarketVolume || 0,
+          averageDailyVolume3Month: quote.averageDailyVolume3Month || 0,
+          fiftyTwoWeekLow: quote.fiftyTwoWeekLow || 0,
+          fiftyTwoWeekHigh: quote.fiftyTwoWeekHigh || 0,
+          dividendYield: quote.dividendYield || null,
+          trailingPE: quote.trailingPE || null,
+          forwardPE: quote.forwardPE || null,
+        };
+      })
+      .filter((quote: any): quote is any => quote !== null);
 
     return new Response(
       JSON.stringify({ quotes }),


### PR DESCRIPTION
This commit introduces the functionality to display consolidated financial data from Open Banking on the investments page and includes fixes for bugs discovered during testing.

- The `useOpenBanking` hook has been extended to fetch and manage investment data from Pluggy.
- The `InvestmentsPage` component now displays Open Banking data, including accounts, transactions, and investments.
- Added defensive checks on the Investments page to prevent crashes from unexpected API data formats (e.g., null balances or missing currency codes).
- The `b3-quotes` Supabase function has been made more resilient to failures from the external Yahoo Finance API, preventing 500 errors and improving application stability.