### PR TITLE
feat: persist open banking connection and remove broker button

### DIFF
--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -81,23 +81,6 @@ const InvestmentsPage = () => {
       setRefreshing(false);
     }
   };
-
-  const handleConnectBroker = () => {
-    // Simular conexão com corretora
-    const mockBrokerId = 'clear-corretora';
-    const mockAccessToken = 'mock-access-token-' + Date.now();
-    
-    localStorage.setItem('connectedBrokerId', mockBrokerId);
-    localStorage.setItem('brokerAccessToken', mockAccessToken);
-    
-    getPortfolio(mockBrokerId, mockAccessToken);
-    getDividends(mockBrokerId, mockAccessToken);
-    
-    toast({
-      title: 'Corretora Conectada',
-      description: 'Conexão com a corretora estabelecida com sucesso.',
-    });
-  };
   const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042'];
 
   const allocationData = useMemo(() => {
@@ -165,12 +148,6 @@ const InvestmentsPage = () => {
           </p>
         </div>
         <div className="flex gap-2">
-          {!b3Connected && (
-            <Button onClick={handleConnectBroker} variant="outline">
-              <LinkIcon className="h-4 w-4 mr-2" />
-              Conectar Corretora
-            </Button>
-          )}
           <Button onClick={handleRefresh} disabled={isLoading} variant="outline">
             <RefreshCw className={`h-4 w-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
             Atualizar

--- a/supabase/migrations/20250905124700_add_pluggy_item_id.sql
+++ b/supabase/migrations/20250905124700_add_pluggy_item_id.sql
@@ -1,0 +1,11 @@
+-- Add the pluggy_item_id column to the stripe_customers table
+ALTER TABLE public.stripe_customers
+ADD COLUMN pluggy_item_id TEXT;
+
+-- Add a policy to allow users to update their own pluggy_item_id
+CREATE POLICY "Users can update their own pluggy_item_id"
+    ON public.stripe_customers
+    FOR UPDATE
+    TO authenticated
+    USING (user_id = auth.uid())
+    WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
This commit implements two user requests:
1.  It makes the Open Banking connection persistent across devices by storing the `pluggy_item_id` in the database, associated with the user's profile. The `useOpenBanking` hook has been refactored to use the database as the single source of truth instead of `localStorage`.
2.  It removes the now-obsolete "Conectar Corretora" (Connect Broker) button and its related handler function from the Investments page.