### PR TITLE
refactor: persist open banking connection in profiles table

### DIFF
--- a/src/hooks/useOpenBanking.ts
+++ b/src/hooks/useOpenBanking.ts
@@ -96,12 +96,12 @@ export const useOpenBanking = () => {
         setLoading(true);
         try {
           const { data, error } = await supabase
-            .from('stripe_customers')
+            .from('profiles')
             .select('pluggy_item_id')
-            .eq('user_id', user.id)
+            .eq('id', user.id)
             .single();
 
-          if (error && error.code !== 'PGRST116') { // PGRST116: 'exact one row not found'
+          if (error) {
             throw error;
           }
 
@@ -161,9 +161,9 @@ export const useOpenBanking = () => {
       const newItemId = data.item.id;
 
       const { error } = await supabase
-        .from('stripe_customers')
+        .from('profiles')
         .update({ pluggy_item_id: newItemId })
-        .eq('user_id', user.id);
+        .eq('id', user.id);
 
       if (error) throw error;
 
@@ -222,9 +222,9 @@ export const useOpenBanking = () => {
 
       // Remover o ID do banco de dados
       await supabase
-        .from('stripe_customers')
+        .from('profiles')
         .update({ pluggy_item_id: null })
-        .eq('user_id', user.id);
+        .eq('id', user.id);
 
       // Limpar o estado local
       setItemId(null);

--- a/supabase/migrations/20250905154500_create_profiles_and_sync_connections.sql
+++ b/supabase/migrations/20250905154500_create_profiles_and_sync_connections.sql
@@ -1,0 +1,50 @@
+-- 1. Revert the previous migration by dropping the policy and column
+
+-- Drop the policy if it exists
+DROP POLICY IF EXISTS "Users can update their own pluggy_item_id" ON public.stripe_customers;
+
+-- Drop the column if it exists
+ALTER TABLE public.stripe_customers
+DROP COLUMN IF EXISTS pluggy_item_id;
+
+
+-- 2. Create the profiles table
+CREATE TABLE public.profiles (
+  id uuid NOT NULL PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  pluggy_item_id TEXT,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+
+-- 3. Set up Row Level Security (RLS) for the profiles table
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can select their own profile"
+  ON public.profiles
+  FOR SELECT
+  TO authenticated
+  USING (auth.uid() = id);
+
+CREATE POLICY "Users can update their own profile"
+  ON public.profiles
+  FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = id)
+  WITH CHECK (auth.uid() = id);
+
+
+-- 4. Create a function to automatically create a profile for new users
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.profiles (id)
+  VALUES (new.id);
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+-- 5. Create a trigger to call the function when a new user is created
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE PROCEDURE public.handle_new_user();


### PR DESCRIPTION
This commit refactors the Open Banking integration to correctly persist the connection information across devices and fixes several related bugs.

- A new `profiles` table has been created to store user-specific data, decoupled from the payments system. A database trigger automatically creates a profile for each new user.
- The `useOpenBanking` hook is refactored to use this `profiles` table to store and retrieve the `pluggy_item_id`, making the connection persistent across devices.
- The previous, incorrect migration that added a column to `stripe_customers` has been reverted.
- The "Conectar Corretora" button has been removed from the UI.
- The `b3-quotes` function is now more resilient to external API failures.
- Defensive checks on the frontend prevent crashes from unexpected data formats (e.g., missing currency codes).